### PR TITLE
use eval to preserve arguments with spaces

### DIFF
--- a/syncd
+++ b/syncd
@@ -70,7 +70,7 @@ case $1 in
     ;;
 
     run)
-      $COMMAND && echo Done.
+      eval "$COMMAND" && echo Done.
     ;;
 
     log)

--- a/watch.sh
+++ b/watch.sh
@@ -83,9 +83,9 @@ inotifywait -m -q -r -e $EVENTS --exclude $WATCH_EXCLUDE --format '%w%f' $WATCH_
     if [ -z "$PID" ]; then
       ## Execute the following as background process.
       ## It runs the command once and repeats if we tell him so.
-	  ($COMMAND; while read -t0.001 -u3 LINE; do
+	  (eval "$COMMAND"; while read -t0.001 -u3 LINE; do
 	    echo running >&4
-	    $COMMAND
+	    eval "$COMMAND"
 	  done)&
 
       PID=$!


### PR DESCRIPTION
using arguments for (e.g.) `RSYNC_OPTIONS` such as `--filter='dir-merge,\n /.gitignore'` will not work using `$COMMAND`, `eval "$COMMAND"` does work. Note that quoting the $COMMAND is important

For more info about this issue: http://stackoverflow.com/questions/2249821/bash-space-in-variable-value-later-used-as-parameter
