### PR TITLE
Added eval to solve inner quote conflict

### DIFF
--- a/syncd
+++ b/syncd
@@ -74,7 +74,7 @@ case $1 in
     ;;
 
     run)
-      $COMMAND && echo Done.
+      eval $COMMAND && echo Done.
     ;;
 
     log)

--- a/syncd
+++ b/syncd
@@ -36,7 +36,7 @@ case $1 in
       export WATCH_EXCLUDE
       export WATCH_VERBOSE
       export WATCH_DIR
-      $SCRIPT_DIR/watch.sh $COMMAND >> $LOGFILE &
+      $SCRIPT_DIR/watch.sh eval $COMMAND >> $LOGFILE &
       echo "$!" > $PIDFILE
       echo "Starting $DAEMON_NAME..."
     ;;


### PR DESCRIPTION
This PR handles the case when we have to mention SSH indentity key instead of user password in syncd.conf. We have to mention the ssh key path with `-e` option, so the variable now becomes
```
RSYNC_OPTIONS="-POzva -e \"/usr/bin/ssh -i /home/user/.ssh/id_rsa\""
```
Without eval, this would output:
```
**Missing trailing-" in remote-shell command.
rsync error: syntax or usage error (code 1) at main.c(430) [sender=3.1.1]**
```

Added eval so command can be executed and no errors comes up for quotes