### PR TITLE
OSX Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,22 @@ Syncd is a simple bash script that watches for file changes and rsyncs them to a
 
 Requirements
 ------------
+
+This script runs on Linux and Mac OS X.
+
+### Linux
+
 Right now a linux based system with inotify-tools and rsync installed is required, .e.g for ubuntu/debian based systems run
 ```
 apt-get install inotify-tools rsync
 ```
 
-For Mac OS X support https://github.com/ggreer/fsevents-tools could be integrated instead of inotify.
+### OS X
+
+OS X use requires fswatch, rsync, and greadline. The easiest way to install these is to install [Homebrew](https://brew.sh/), and then run the following command:
+```
+brew install rsync fswatch coreutils
+```
 
 
 Installation

--- a/syncd
+++ b/syncd
@@ -18,9 +18,14 @@ while [ ! -e $CONF_FILE ]; do
 done
 
 SYNCD_CONFIG_DIR=$PWD
-SCRIPT=`readlink -f $0`
+if [ `uname` == "Linux" ];then
+  SCRIPT=`readlink -f $0`
+  LINK=`readlink -f $0`
+elif [ `uname` == "Darwin" ];then
+  SCRIPT=`greadlink -f $0`
+  LINK=`greadlink -f $0`
+fi
 DAEMON_NAME=syncd
-LINK=`readlink -f $0`
 SCRIPT_DIR=`dirname $LINK`
 
 . $CONF_FILE


### PR DESCRIPTION
This patch for OSX support has more installation requirements than the previous one, but uses a more direct command substitution and leaves Linux timeout defaults in place. It supports all configuration variables except for WATCH_EXCLUDE.